### PR TITLE
Provide TypeScript declarations for the module

### DIFF
--- a/lib/node-sourcekit.d.ts
+++ b/lib/node-sourcekit.d.ts
@@ -1,0 +1,26 @@
+declare module SourceKit {
+
+    export interface ICursorOption {
+        sourcefile: string,
+        offset: number,
+        compilerargs: string[]
+    }
+
+    export interface ICursorInfo {
+        'key.kind': string,
+        'key.name': string,
+        'key.usr': string,
+        'key.filepath': string,
+        'key.offset': number,
+        'key.length': number,
+        'key.typename': string
+        'key.annotated_decl': string
+        'key.fully_annotated_decl': string
+        'key.typeusr': string
+    }
+
+    export function cursorinfo(options: ICursorOption): Promise<ICursorInfo>
+
+}
+
+export = SourceKit;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": "~6.3.0"
   },
   "main": "./lib/node-sourcekit",
+  "typings": "./lib/node-sourcekit.d.ts",
   "keywords": [
     "SourceKit",
     "swift",


### PR DESCRIPTION
Resolves #8.

I really do not like the `ICursorInfo` definition. I'm also ambivalent to the naming scheme I've chosen here. Just needed to get _something_ in place to start testing integration with VSCode.

I think mapping the `ICursorInfo` properties from `'key.kind'` => `key` would be better. Also possibly outputing `key.kind` as an enum would be better too.

These are things that can be improved subsequently.

/cc: @aaroncrespo
